### PR TITLE
Update SCIPSolverInterface.jl

### DIFF
--- a/src/SCIPSolverInterface.jl
+++ b/src/SCIPSolverInterface.jl
@@ -135,7 +135,8 @@ getobjval(m::SCIPMathProgModel) = _SCIPgetPrimalbound(m.ptr)
 getobjbound(m::SCIPMathProgModel) = _SCIPgetDualbound(m.ptr)
 
 function getsolution(m::SCIPMathProgModel)
-    sol  = SPtr(_SCIP_SOL)
+    #sol  = SPtr(_SCIP_SOL)
+    sol = _SCIPgetBestSol(m.ptr)
     return [_SCIPgetSolVal(m.ptr, sol, m.vars[i]) for i in 1:numvar(m)]
 end
 


### PR DESCRIPTION
The changes are following. It seems the previous code parses solution from the uninitialized pointer. The solution must be taken from the problem by _SCIPgetBestSol(). It may need if-statement to check whether a solution is available or not.
```julia
 function getsolution(m::SCIPMathProgModel)
-    sol  = SPtr(_SCIP_SOL)
+    #sol  = SPtr(_SCIP_SOL)
+    sol = _SCIPgetBestSol(m.ptr)
     return [_SCIPgetSolVal(m.ptr, sol, m.vars[i]) for i in 1:numvar(m)]
 end
```