### PR TITLE
Convert C char* to Ptr{Uint8}, fix name of type maps

### DIFF
--- a/src/helper/convenience.jl
+++ b/src/helper/convenience.jl
@@ -9,8 +9,11 @@ function SCIPcreate()
     return scip
 end
 
-SCIPcreateVarBasic(scip::SPtr{_SCIP},lb,ub,obj,vartype::_SCIP_VARTYPE) = 
-    SCIPcreateVarBasic(scip,"",lb,ub,obj,vartype)
+function SCIPcreateVarBasic(scip::SPtr{_SCIP}, lb, ub, obj, vartype::_SCIP_VARTYPE)
+    var = SPtr(_SCIP_VAR)
+    _SCIPcreateVarBasic(scip, pointer(var), 0, convert(_SCIP_Real,lb), convert(_SCIP_Real,ub), convert(_SCIP_Real,obj), vartype)
+    return var
+end
 
 function SCIPcreateVarBasic(scip::SPtr{_SCIP}, name::String, lb, ub, obj, vartype::_SCIP_VARTYPE)
     var = SPtr(_SCIP_VAR)

--- a/templates/wrapped/scip_enums.jl
+++ b/templates/wrapped/scip_enums.jl
@@ -3,7 +3,7 @@
 typealias {{ .FinalName }} Int8
 {{ range .Values }}const {{ .FinalName }} = int8({{ .Init }})
 {{ end }}
-const {{ .OrigName }}s_MAP = [
+const {{ .OrigName }}_MAP = [
 {{ range .Values }}    {{ .FinalName }} => "{{ .Description }}",
 {{ end }}]
 

--- a/x/scipgen/convert.go
+++ b/x/scipgen/convert.go
@@ -6,7 +6,7 @@ import "strings"
 var TYPE_MAP = map[string]string{
 	"SCIP_Longint": "Int64",
 	"char":         "Char",
-	"char *":       "String",
+	"char *":       "Ptr{Uint8}",
 	"double":       "Float64",
 	"int":          "Int",
 	"unsigned int": "Uint",


### PR DESCRIPTION
Converting char\* to String didn't work, should use Ptr{Uint8}, see http://julia.readthedocs.org/en/latest/manual/calling-c-and-fortran-code/. 

Fix the name of the MAP -- actual map names {{.Origname}}s_MAP did not match the exported name {{.OrigName}}_MAP
