### PR TITLE
Load libipopt, if available #25

### DIFF
--- a/src/SCIP.jl
+++ b/src/SCIP.jl
@@ -1,8 +1,10 @@
 module SCIP
 
-# if SCIP is compiled with Ipopt, libipopt must be in LD_LIBRARY_PATH
-if (libipopt = find_library(["libipopt"])) != ""
-   @unix_only dlopen(libipopt, RTLD_LAZY|RTLD_DEEPBIND|RTLD_GLOBAL)
+function __init__()
+   # if SCIP is compiled with Ipopt, libipopt must be in LD_LIBRARY_PATH
+   if (libipopt = find_library(["libipopt"])) != ""
+      @unix_only dlopen(libipopt, RTLD_LAZY|RTLD_DEEPBIND|RTLD_GLOBAL)
+   end
 end
 
 # dump all code wrapped from C interface

--- a/src/SCIP.jl
+++ b/src/SCIP.jl
@@ -1,5 +1,10 @@
 module SCIP
 
+# if SCIP is compiled with Ipopt, libipopt must be in LD_LIBRARY_PATH
+if (libipopt = find_library(["libipopt"])) != ""
+   @unix_only dlopen(libipopt, RTLD_LAZY|RTLD_DEEPBIND|RTLD_GLOBAL)
+end
+
 # dump all code wrapped from C interface
 module CInterface
     include("wrapped/scip_defines.jl")


### PR DESCRIPTION
Load Ipopt shared library. Necessary if scipoptlib is compiled with IPOPT=true.